### PR TITLE
Helm Chartを修正

### DIFF
--- a/helm/subscription-manager/onepassworditem.yaml
+++ b/helm/subscription-manager/onepassworditem.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: subscription-manager-credentials
+  namespace: subscription-manager
+spec:
+  itemPath: vaults/Kubernetes/items/subscription-manager-credentials

--- a/helm/subscription-manager/values.pke.yaml
+++ b/helm/subscription-manager/values.pke.yaml
@@ -4,14 +4,14 @@ ingress:
   annotations: 
     cert-manager.io/cluster-issuer: letsencrypt
   hosts:
-    - host: subscription-manager.tailscale.str08.net
+    - host: subscription-manager.str08.net
       paths:
         - path: /
           pathType: Prefix
   tls:
-    - secretName: subscription-manager.tailscale.str08.net-dns01
+    - secretName: subscription-manager.str08.net-dns01
       hosts:
-        - subscription-manager.tailscale.str08.net
+        - subscription-manager.str08.net
 
 credentials:
   external: true

--- a/helm/subscription-manager/values.pke.yaml
+++ b/helm/subscription-manager/values.pke.yaml
@@ -1,0 +1,18 @@
+ingress:
+  enabled: true
+  className: "traefik"
+  annotations: 
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: subscription-manager.tailscale.str08.net
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: subscription-manager.tailscale.str08.net-dns01
+      hosts:
+        - subscription-manager.tailscale.str08.net
+
+credentials:
+  external: true
+  externalName: "subscription-manager-credentials"

--- a/helm/subscription-manager/values.yaml
+++ b/helm/subscription-manager/values.yaml
@@ -1,9 +1,9 @@
 replicaCount: 1
 
 image:
-  repository: subscription-manager
+  repository: ghcr.io/soli0222/subscription-manager
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: "1.0.0"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
This pull request introduces configuration updates for the `subscription-manager` Helm chart, focusing on integrating OnePassword for credential management, enabling ingress, and updating the container image repository and tag. Below is a breakdown of the most important changes:

### Credential Management Integration:

* Added a new `OnePasswordItem` resource in `helm/subscription-manager/onepassworditem.yaml` to manage credentials securely via OnePassword. (`[helm/subscription-manager/onepassworditem.yamlR1-R7](diffhunk://#diff-16c21f6232b38eb2bfcf3ca372d9fd9a19d6310b8bc4c43ec030a99c94eb16b1R1-R7)`)
* Updated `helm/subscription-manager/values.pke.yaml` to reference external credentials managed by OnePassword. (`[helm/subscription-manager/values.pke.yamlR1-R18](diffhunk://#diff-f5b38a6b11234593311a11829d330860dd1d87146563f2974dabd7331bb400c2R1-R18)`)

### Ingress Configuration:

* Enabled ingress in `helm/subscription-manager/values.pke.yaml`, specifying a `traefik` ingress class, TLS settings, and a hostname for the subscription manager. (`[helm/subscription-manager/values.pke.yamlR1-R18](diffhunk://#diff-f5b38a6b11234593311a11829d330860dd1d87146563f2974dabd7331bb400c2R1-R18)`)

### Container Image Update:

* Changed the container image repository to `ghcr.io/soli0222/subscription-manager` and updated the tag to `1.0.0` in `helm/subscription-manager/values.yaml`. (`[helm/subscription-manager/values.yamlL4-R6](diffhunk://#diff-c5ff0248fbcde36d5467e7723536a62324552aabc3074576e11df2f1184bef13L4-R6)`)